### PR TITLE
Correct config file name

### DIFF
--- a/rootfs/etc/run_always/populate
+++ b/rootfs/etc/run_always/populate
@@ -23,7 +23,7 @@ if [ ! -d /web/logs ]; then
   chown -R nginx.nginx /web/logs
 fi
 
-if [ ! -f /web/config/httpd.conf ]; then
+if [ ! -f /web/config/nginx.conf ]; then
   cp -R /etc/nginx/* /web/config/
   chown -R nginx.nginx /web/config
 fi


### PR DESCRIPTION
File name httpd.conf is never found because that's for Apache. Should actually be looking for nginx.conf. As is, this script overwrites your config file every time.